### PR TITLE
Enable non-hardware simulation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Optional (recommended) arguments:
           AUTO_CAN:=true|false  (default is true)
           CAN_DEVICE:=/dev/pcanusb1 | /dev/pcanusbNNN  (ls -l /dev/pcan* to see open CAN devices)
           VISUALIZE:=true|false  (Launch rviz)
+          SIM:=true|false  (use a joint_state_publisher instead of the actual robot)
 
 Note on `AUTO_CAN`: There is a nice script `detect_pcan.py` which automatically
 finds an open `/dev/pcanusb` file. If instead you specify the can device

--- a/allegro_hand_controllers/launch/allegro_hand.launch
+++ b/allegro_hand_controllers/launch/allegro_hand.launch
@@ -11,7 +11,7 @@
           AUTO_CAN:=true|false  (if true, ignores CAN_DEVICE argument and finds the can device automagically).
           CAN_DEVICE:=/dev/pcanusb1 | /dev/pcanusbNNN  (ls -l /dev/pcan* to see open CAN devices)
           VISUALIZE:=true|false  (Launch rviz)
-          SIM:=true|false  (use a join_state_publisher instead of the actual robot)
+          SIM:=true|false  (use a joint_state_publisher instead of the actual robot)
 
        This script launches the following nodes:
          - allegro hand controller (different controllers exist)

--- a/allegro_hand_controllers/launch/allegro_hand.launch
+++ b/allegro_hand_controllers/launch/allegro_hand.launch
@@ -11,6 +11,7 @@
           AUTO_CAN:=true|false  (if true, ignores CAN_DEVICE argument and finds the can device automagically).
           CAN_DEVICE:=/dev/pcanusb1 | /dev/pcanusbNNN  (ls -l /dev/pcan* to see open CAN devices)
           VISUALIZE:=true|false  (Launch rviz)
+          SIM:=true|false  (use a join_state_publisher instead of the actual robot)
 
        This script launches the following nodes:
          - allegro hand controller (different controllers exist)
@@ -28,6 +29,7 @@
        as an input for both the robot_description and for the grasping library controllers. -->
   <arg name="HAND"/>
   <arg name="NUM" default='0'/>
+  <arg name="SIM" default='false'/>
 
   <!-- Visualization with rviz, only if arg VISUALIZE is set to true. Default is
        false, the allegro_viz.launch can be started separated. -->
@@ -70,7 +72,8 @@
          command="$(find xacro)/xacro.py
                   $(find allegro_hand_description)/allegro_hand_description_$(arg HAND).xacro"/>
 
-  <!-- Allegro Hand controller and communication node -->
+  <!-- Allegro Hand controller and communication node. Only if SIM is false
+       (otherwise use the joint_state_publisher. -->
   <node name="allegroHand_$(arg HAND)_$(arg NUM)"
         pkg="allegro_hand_controllers"
         type="allegro_node_$(arg CONTROLLER)"
@@ -78,7 +81,8 @@
         clear_params="true"
         respawn="$(arg RESPAWN)"
         respawn_delay="2"
-        args="$(arg POLLING)" >
+        args="$(arg POLLING)"
+        unless="$(arg SIM)" >
 
     <!-- Remapping of topics into enumerated allegroHand_# namespace -->
     <remap from="/allegroHand/joint_states" to="/allegroHand_$(arg NUM)/joint_states"/>
@@ -107,6 +111,12 @@
            if="$(arg AUTO_CAN)" />
 
     <param name="/hand_info/which_hand" value="$(arg HAND)" /> <!-- See HAND arg above -->
+  </node>
+
+  <node name="joint_states_$(arg NUM)" pkg="joint_state_publisher" type="joint_state_publisher"
+        if="$(arg SIM)">
+    <remap from="/joint_states" to="/allegroHand_$(arg NUM)/joint_states"/>
+    <param name="use_gui" value="true"/>
   </node>
 
   <!-- Joint States (angles) to Joint Transforms -->

--- a/epfl_allegro_launchers/README.md
+++ b/epfl_allegro_launchers/README.md
@@ -1,0 +1,5 @@
+This is an example of a package whose only purpose is to serve as launch aliases
+with the desired parameters.
+
+You can add a new launch package instead of editing the generic launch files
+directly.

--- a/epfl_allegro_launchers/launch/epfl_left.launch
+++ b/epfl_allegro_launchers/launch/epfl_left.launch
@@ -8,6 +8,7 @@
   <arg name="ZEROS" default="$(find allegro_hand_parameters)/zero_files/zero_SAH020BL016.yaml" />
   <arg name="AUTO_CAN" default="true" />  <!--If true, ignores CAN_DEVICE. -->
   <arg name="CAN_DEVICE" default="/dev/pcanusb1" />
+  <arg name="SIM" default="false" />
 
   <include file="$(find allegro_hand_controllers)/launch/allegro_hand.launch">
     <arg name="HAND" value="$(arg HAND)"/>
@@ -18,6 +19,7 @@
     <arg name="ZEROS" value="$(arg ZEROS)"/>
     <arg name="AUTO_CAN" value="$(arg AUTO_CAN)"/>
     <arg name="CAN_DEVICE" value="$(arg CAN_DEVICE)"/>
+    <arg name="SIM" value="$(arg SIM)"/>
   </include>
 
 </launch>

--- a/epfl_allegro_launchers/launch/epfl_right.launch
+++ b/epfl_allegro_launchers/launch/epfl_right.launch
@@ -8,6 +8,7 @@
   <arg name="ZEROS" default="$(find allegro_hand_parameters)/zero_files/zero_SAH020BR012.yaml" />
   <arg name="AUTO_CAN" default="true" />  <!--If true, ignores CAN_DEVICE. -->
   <arg name="CAN_DEVICE" default="/dev/pcanusb1" />
+  <arg name="SIM" default="false" />
 
   <include file="$(find allegro_hand_controllers)/launch/allegro_hand.launch">
     <arg name="HAND" value="$(arg HAND)"/>
@@ -18,6 +19,7 @@
     <arg name="ZEROS" value="$(arg ZEROS)"/>
     <arg name="AUTO_CAN" value="$(arg AUTO_CAN)"/>
     <arg name="CAN_DEVICE" value="$(arg CAN_DEVICE)"/>
+    <arg name="SIM" value="$(arg SIM)"/>
   </include>
 
 </launch>


### PR DESCRIPTION
Launches joint_state_publisher instead of using the actual hardware.
